### PR TITLE
Added new resize master `Image::ADAPT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ $image->watermark(Image $watermark, $offset_x = NULL, $offset_y = NULL, $opacity
 ```
 **Using resize with resize constrains**
 ```php
-$image->resize($width,$height,Yii\image\drivers\Image::HEIGHT);
+$image->resize($width, $height, Yii\image\drivers\Image::HEIGHT);
+$image->resize($width, $height, Yii\image\drivers\Image::ADAPT)->background('#fff');
 ```
 Possible resize constrains:
 ```php
@@ -65,6 +66,7 @@ Possible resize constrains:
     const AUTO    = 0x04;
     const INVERSE = 0x05;
     const PRECISE = 0x06;
+    const ADAPT   = 0x07;
 ```
 **Using flip with flipping directions**
 ```php

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Possible resize constrains:
     const INVERSE = 0x05;
     const PRECISE = 0x06;
     const ADAPT   = 0x07;
+    const CROP    = 0x08;
 ```
 **Using flip with flipping directions**
 ```php

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ $image->watermark(Image $watermark, $offset_x = NULL, $offset_y = NULL, $opacity
 ```
 **Using resize with resize constrains**
 ```php
-$image->resize($width, $height, Yii\image\drivers\Image::HEIGHT);
-$image->resize($width, $height, Yii\image\drivers\Image::ADAPT)->background('#fff');
+$image->resize($width, $height, \yii\image\drivers\Image::HEIGHT);
+$image->resize($width, $height, \yii\image\drivers\Image::ADAPT)->background('#fff');
 ```
 Possible resize constrains:
 ```php
@@ -72,7 +72,7 @@ Possible resize constrains:
 **Using flip with flipping directions**
 ```php
 // Flipping directions ($direction)
-$image->flip(Yii\image\drivers\Image::HORIZONTAL);
+$image->flip(\yii\image\drivers\Image::HORIZONTAL);
 ```
 Possible flipping directions:
 ```php

--- a/yii/image/drivers/Kohana/Image.php
+++ b/yii/image/drivers/Kohana/Image.php
@@ -20,6 +20,7 @@ abstract class Kohana_Image {
         const AUTO    = 0x04;
         const INVERSE = 0x05;
         const PRECISE = 0x06;
+        const ADAPT   = 0x07;
 
         // Flipping directions
         const HORIZONTAL = 0x11;
@@ -172,6 +173,11 @@ abstract class Kohana_Image {
          *
          *     // Resize to 200x500 pixels, ignoring aspect ratio
          *     $image->resize(200, 500, Image::NONE);
+         * 
+         *     // Resize to 400 pixels on the shortest side, puts it in the center 
+         *     // of the image with the transparent edges, keeping aspect ratio, 
+         *     // output size will be 400x400 pixels
+         *     $image->resize(400, 400, Image::ADAPT);
          *
          * @param   integer  $width   new width
          * @param   integer  $height  new height
@@ -201,6 +207,17 @@ abstract class Kohana_Image {
 
                         // Set empty width for backward compatibility
                         $width = NULL;
+                }
+                elseif ($master === Image::ADAPT) 
+                {
+                        if (empty($width)) 
+                        {
+                                $width = $this->width * $height / $this->height;
+                        } 
+                        elseif (empty($height)) 
+                        {
+                                $height = $this->height * $width / $this->width;
+                        }
                 }
 
                 if (empty($width))
@@ -271,6 +288,28 @@ abstract class Kohana_Image {
                 // Convert the width and height to integers, minimum value is 1px
                 $width  = max(round($width), 1);
                 $height = max(round($height), 1);
+
+                // Adapt the image if the ratios are not equivalent
+                if ($master === Image::ADAPT && $width / $height !== $this->width / $this->height)
+                {
+                        $image_width = $bg_width = $this->width;
+                        $image_height = $bg_height = $this->height;
+
+                        $offset_x = $offset_y = 0;
+
+                        if ($width / $height > $image_width / $image_height) 
+                        {
+                                $bg_width = floor($image_height * $width / $height);
+                                $offset_x = abs(floor(($bg_width - $image_width) / 2));
+                        }
+                        else 
+                        {
+                                $bg_height = floor($image_width * $height / $width);
+                                $offset_y = abs(floor(($bg_height - $image_height) / 2));
+                        }
+
+                        $this->_do_adapt($image_width, $image_height, $bg_width, $bg_height, $offset_x, $offset_y);
+                }
 
                 $this->_do_resize($width, $height);
 
@@ -675,6 +714,18 @@ abstract class Kohana_Image {
          * @return  void
          */
         abstract protected function _do_resize($width, $height);
+
+        /**
+         * Adaptation the image.
+         * 
+         * @param   integer  $width      image width
+         * @param   integer  $height     image height
+         * @param   integer  $bg_width   background width
+         * @param   integer  $bg_height  background height
+         * @param   integer  $offset_x   offset from the left
+         * @param   integer  $offset_y   offset from the top
+         */
+        abstract protected function _do_adapt($width, $height, $bg_width, $bg_height, $offset_x, $offset_y);
 
         /**
          * Execute a crop.

--- a/yii/image/drivers/Kohana/Image.php
+++ b/yii/image/drivers/Kohana/Image.php
@@ -21,6 +21,7 @@ abstract class Kohana_Image {
         const INVERSE = 0x05;
         const PRECISE = 0x06;
         const ADAPT   = 0x07;
+        const CROP    = 0x08;
 
         // Flipping directions
         const HORIZONTAL = 0x11;
@@ -191,6 +192,25 @@ abstract class Kohana_Image {
                 {
                         // Choose the master dimension automatically
                         $master = Image::AUTO;
+                }
+                elseif ($master === Image::CROP)
+                {
+                        if (empty($width) || empty($height))
+                        {
+                                return $this->resize($width, $height, Image::AUTO);
+                        }
+
+                        $master = $this->width / $this->height > $width / $height ? Image::HEIGHT : Image::WIDTH;
+                        $this->resize($width, $height, $master);
+
+                        if ($this->width !== $width || $this->height !== $height) 
+                        {
+                                $offset_x = round(($this->width - $width) / 2);
+                                $offset_y = round(($this->height - $height) / 2);
+                                $this->crop($width, $height, $offset_x, $offset_y);
+                        }
+
+                        return $this;
                 }
                 // Image::WIDTH and Image::HEIGHT deprecated. You can use it in old projects,
                 // but in new you must pass empty value for non-master dimension

--- a/yii/image/drivers/Kohana/Image/GD.php
+++ b/yii/image/drivers/Kohana/Image/GD.php
@@ -69,10 +69,10 @@ class Kohana_Image_GD extends Kohana_Image {
                 return Image_GD::$_checked = TRUE;
         }
 
-        // Temporary image resource
+        /* @var resource Temporary image resource */
         protected $_image;
 
-        // Function name to open Image
+        /* @var string Function name to open Image */
         protected $_create_function;
 
         /**
@@ -207,6 +207,33 @@ class Kohana_Image_GD extends Kohana_Image {
                         $this->width  = imagesx($image);
                         $this->height = imagesy($image);
                 }
+        }
+
+        /**
+         * Adaptation the image.
+         *
+         * @param   integer  $width      image width
+         * @param   integer  $height     image height
+         * @param   integer  $bg_width   background width
+         * @param   integer  $bg_height  background height
+         * @param   integer  $offset_x   offset from the left
+         * @param   integer  $offset_y   offset from the top
+         */
+        protected function _do_adapt($width, $height, $bg_width, $bg_height, $offset_x, $offset_y)
+        {
+                $this->_load_image();
+                $image = $this->_image;
+                $this->_image = $this->_create($bg_width, $bg_height);
+                $this->width = $bg_width;
+                $this->height = $bg_height;
+                imagealphablending($this->_image, false);
+                $col = imagecolorallocatealpha($this->_image, 0, 255, 0, 127);
+                imagefilledrectangle($this->_image, 0, 0, $bg_width, $bg_height, $col);
+                imagealphablending($this->_image, true);
+                imagecopy($this->_image, $image, $offset_x, $offset_y, 0, 0, $width, $height);
+                imagealphablending($this->_image, false);
+                imagesavealpha($this->_image, true);
+                imagedestroy($image);
         }
 
         /**

--- a/yii/image/drivers/Kohana/Image/Imagick.php
+++ b/yii/image/drivers/Kohana/Image/Imagick.php
@@ -88,6 +88,28 @@ class Kohana_Image_Imagick extends Kohana_Image {
                 return FALSE;
         }
 
+        /**
+         * Adaptation the image.
+         *
+         * @param   integer  $width      image width
+         * @param   integer  $height     image height
+         * @param   integer  $bg_width   background width
+         * @param   integer  $bg_height  background height
+         * @param   integer  $offset_x   offset from the left
+         * @param   integer  $offset_y   offset from the top
+         */
+        protected function _do_adapt($width, $height, $bg_width, $bg_height, $offset_x, $offset_y)
+        {
+                $image = new Imagick();
+                $image->newImage($bg_width, $bg_height, "none");
+                $image->compositeImage($this->im, Imagick::COMPOSITE_ADD, $offset_x, $offset_y);
+                $this->im->clear();
+                $this->im->destroy();
+                $this->im = $image;
+                $this->width = $bg_width;
+                $this->height = $bg_height;
+        }
+
         protected function _do_crop($width, $height, $offset_x, $offset_y)
         {
                 if ($this->im->cropImage($width, $height, $offset_x, $offset_y))


### PR DESCRIPTION
When using master `Image::ADAPT`:
- the output image size is always equal to the specified;
- keeps aspect ratio to the original image;
- puts the original image on the center of the output image with the transparent edges, when the ratios of input and output not equal.